### PR TITLE
Modify body-line-height value

### DIFF
--- a/themes/metro.yaml
+++ b/themes/metro.yaml
@@ -93,7 +93,7 @@ ________________________________Metro Dark Common Attributes (DO NOT USE): &metr
   # Body at 14px = 10.5pt = 1rem
   body-font-size: 1rem
   body-font-weight: normal
-  body-line-height: 1
+  body-line-height: 1.5
   card-title-font-size: 1.5rem
   card-title-font-weight: 500
   card-title-line-height: 1.1
@@ -355,7 +355,7 @@ ________________________________Metro Light Common Attributes (DO NOT USE): &met
   # Body at 14px = 10.5pt = 1rem
   body-font-size: 1rem
   body-font-weight: normal
-  body-line-height: 1
+  body-line-height: 1.5
   card-title-font-size: 1.5rem
   card-title-font-weight: 500
   card-title-line-height: 1

--- a/themes/metro.yaml
+++ b/themes/metro.yaml
@@ -587,7 +587,7 @@ ________________________________Metro Light Common Attributes (DO NOT USE): &met
     $: |
       .mdc-dialog__surface {
         backdrop-filter: blur(8px);
-        background-color: rgba(var(--rgb-mdc-theme-surface), .5) !important;
+        background-color: rgba(var(--rgb-mdc-theme-surface), 1.0) !important;
       }
     ha-header-bar$: |
       .mdc-top-app-bar {

--- a/themes/metro.yaml
+++ b/themes/metro.yaml
@@ -140,7 +140,7 @@ ________________________________Metro Dark Common Attributes (DO NOT USE): &metr
 
   # Layout
   ha-card-border-radius: "0"
-  masonry-view-card-margin: "1px"
+  masonry-view-card-margin: "2px"
   grid-card-gap: "2px"
   stack-card-margin: "1px"
 
@@ -403,7 +403,7 @@ ________________________________Metro Light Common Attributes (DO NOT USE): &met
   # Layout
   ha-card-border-radius: "4px"
   ha-dialog-border-radius: "8px"
-  masonry-view-card-margin: "1px"
+  masonry-view-card-margin: "2px"
   grid-card-gap: "2px"
   stack-card-margin: "1px"
 


### PR DESCRIPTION
This fixes lowercase "p", "g" & "y" characters being cut off.. 

Before:
![Capture](https://user-images.githubusercontent.com/5051561/168410765-17b120eb-e044-459f-84b9-764f23a7a0d3.PNG)

After:
![Capture2](https://user-images.githubusercontent.com/5051561/168410768-81adb337-f732-47d0-acc1-7b40a29bffe0.PNG)
