### PR TITLE
Remove dialog transparency for firefox users

### DIFF
--- a/themes/metro.yaml
+++ b/themes/metro.yaml
@@ -632,6 +632,11 @@ ________________________________Metro Light Common Attributes (DO NOT USE): &met
         backdrop-filter: blur(16px);
         background-color: rgba(var(--rgb-mdc-theme-surface), .5) !important;
       }
+      @-moz-document url-prefix() {
+        .mdc-dialog__surface {
+          background-color: rgba(var(--rgb-mdc-theme-surface), 1.0) !important;
+        }
+      }
     ha-header-bar$: |
       .mdc-top-app-bar {
         background: none !important;


### PR DESCRIPTION
Removes transparency just for firefox users.

Before:
![Capture3](https://user-images.githubusercontent.com/5051561/168496473-988472f2-01fe-4803-b926-cb7febcec1d1.png)

After:
![Capture4](https://user-images.githubusercontent.com/5051561/168496483-cb25bb9f-2780-49b9-929e-4589bef48b24.png)
