### PR TITLE
Fall back to system-ui before sans-serif

### DIFF
--- a/themes/metro.yaml
+++ b/themes/metro.yaml
@@ -78,8 +78,8 @@ ________________________________Metro Dark Common Attributes (DO NOT USE): &metr
   mdc-theme-on-primary: var(--accent-text-color)
 
   # Typography
-  font-stack: &font-stack "Segoe UI Variable Static Text, Segoe UI, SegoeUI, -apple-system,BlinkMacSystemFont, sans-serif"
-  display-font-stack: &display-font-stack "Segoe UI Variable Static Display, Segoe UI, SegoeUI, -apple-system,BlinkMacSystemFont, sans-serif"
+  font-stack: &font-stack "Segoe UI Variable Static Text, Segoe UI, SegoeUI, -apple-system,BlinkMacSystemFont, system-ui, sans-serif"
+  display-font-stack: &display-font-stack "Segoe UI Variable Static Display, Segoe UI, SegoeUI, -apple-system,BlinkMacSystemFont, system-ui, sans-serif"
   mdc-typography-button-font-family: var(--font-stack)
   mdc-typography-font-family: var(--font-stack)
   paper-font-common-base_-_font-family: var(--font-stack)


### PR DESCRIPTION
The default sans-serif font is a bit ugly on some systems. Use the system's font instead.