### PR TITLE
Add Browser Mod Popup Support

### DIFF
--- a/themes/metro.yaml
+++ b/themes/metro.yaml
@@ -61,6 +61,7 @@ ________________________________________Common Base (Do Not Use): &common-colors
   # Borders
   ha-card-border-width: 0px
   ha-card-border-color: transparent
+  popup-border-radius: var(--ha-dialog-border-radius)
 
   # Typography
   font-stack: &font-stack "Segoe UI Variable Static Text, Segoe UI, SegoeUI, -apple-system,BlinkMacSystemFont, system-ui, sans-serif"
@@ -523,6 +524,17 @@ ________________________________________Common Base 3 (Do Not Use): &common-card
       .mdc-dialog__surface {
         box-shadow: 0 0px 16px 4px rgba(var(--dialog-box-shadow), .15), 0 16px 64px 32px rgba(var(--dialog-box-shadow), .5) !important;
       }
+    ha-dialog$: |
+      @supports (-webkit-backdrop-filter: none) or (backdrop-filter: none) {
+        .mdc-dialog__surface {
+          backdrop-filter: blur(16px);
+          -webkit-backdrop-filter: blur(16px);
+          background-color: rgba(var(--rgb-mdc-theme-surface), .5) !important;
+        }
+      }
+      .mdc-dialog__surface {
+        box-shadow: 0 0px 16px 4px rgba(var(--dialog-box-shadow), .15), 0 16px 64px 32px rgba(var(--dialog-box-shadow), .5) !important;
+      }
     ha-header-bar$: |
       .mdc-top-app-bar {
         background: none !important;
@@ -539,6 +551,9 @@ ________________________________________Common Base 3 (Do Not Use): &common-card
       }
       .content {
         xmargin-top: -8px;
+      }
+      ha-dialog {
+        --dialog-box-shadow: inherit !important;
       }
     ha-more-info-info$state-card-display$: |
       .state {


### PR DESCRIPTION
This adds support for [Browser Mod](https://github.com/thomasloven/hass-browser_mod) Popups

<details><summary>Fluent Blue Light</summary>

Before
![fluent-blue-light-before](https://user-images.githubusercontent.com/1580378/222933533-4418ef3d-96a4-443e-bc2b-f50b6aea6b85.png)

After
![fluent-blue-light-after](https://user-images.githubusercontent.com/1580378/222933537-926f225a-0463-4af8-9d55-e32c78fb7714.png)

</details>

<details><summary>Fluent Blue Dark</summary>

Before
![fluent-blue-dark-before](https://user-images.githubusercontent.com/1580378/222933543-ff7f22c3-0409-4271-b813-17e423e5798d.png)

After
![fluent-blue-dark-after](https://user-images.githubusercontent.com/1580378/222933544-fe26d4ee-e445-431d-8a94-16e2c74ad2c4.png)

</details>

<details><summary>Metro Blue Light</summary>

Before
![metro-blue-light-before](https://user-images.githubusercontent.com/1580378/222933554-f257fa2a-66de-4d9b-8d24-bcae2e574cb2.png)

After
![metro-blue-light-after](https://user-images.githubusercontent.com/1580378/222933556-21117ac4-eceb-4243-9b11-2a6bf6dffdb1.png)

</details>

<details><summary>Metro Blue Dark</summary>

Before
![metro-blue-dark-before](https://user-images.githubusercontent.com/1580378/222933562-f99961f0-62aa-4b1a-96f5-0cac64f38666.png)

After
![metro-blue-dark-after](https://user-images.githubusercontent.com/1580378/222933563-1e2c2086-0411-4285-aeeb-823468182877.png)

</details>